### PR TITLE
Remove 50% width

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -87,7 +87,9 @@
 }
 
 #app-content textarea.markdown {
-	width: 50%;
+	/* 
+	* width: 50%;
+	*/
 }
 
 /* TODO: move into core app styles */
@@ -99,7 +101,9 @@
 
 #app-content .markdown {
 	height: 100%;
-	width: 50%;
+	/*
+	* width: 50%;
+	*/
 	margin: 0;
 	padding: 30px 20px 100px 30px;
 	font-size: 18px;


### PR DESCRIPTION
Without this only 50% of the space is used since the markdown overview isn't there anymore.

Before:

![screen shot 2014-05-29 at 22 18 20](https://cloud.githubusercontent.com/assets/878997/3123046/72325494-e76e-11e3-8dc5-fa8f03ba5905.png)

After:
![screen shot 2014-05-29 at 22 19 21](https://cloud.githubusercontent.com/assets/878997/3123051/8cae9788-e76e-11e3-927f-9608cf6cef2b.png)
