### PR TITLE
Fix: The loading icon doesn't fly anymore.

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -97,6 +97,10 @@
 	background-image: url('../img/loading.gif');
 	background-position: center;
 	background-repeat: no-repeat;
+	/* Overrides the snap.js animation making the loading icon to fly in app-content. */
+	transition:none !important;
+	-webkit-transition: none !important;
+	-moz-webkit-transition: none !important;
 }
 
 #app-content .markdown {

--- a/templates/main.php
+++ b/templates/main.php
@@ -54,5 +54,7 @@
 		</ul>
 	</div>
 
-	<div id="app-content" ng-view ng-class="{loading: is.loading}"></div>
+	<div id="app-content" ng-class="{loading: is.loading}">
+		<div id="app-content-container" ng-view></div>
+	</div>
 </div>


### PR DESCRIPTION
I have overridden styles coming from snap.js to fix this. Please check, any more solutions are welcome. :dancer: 
 Fix for : https://github.com/owncloud/notes/issues/64

@owncloud/designers @jancborchardt @Raydiation 
