### PR TITLE
Mobile-friendly padding in note view.

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -105,7 +105,7 @@
 	* width: 50%;
 	*/
 	margin: 0;
-	padding: 30px 20px 100px 30px;
+	padding: 1.5%;
 	font-size: 18px;
 	line-height: 1.5;
 	border: 0;


### PR DESCRIPTION
Change the padding in the note view from fixed-pixel sizes to a mobile-friendly percentage. Allows nicer viewing and editing of notes on mobile devices. Tested on Firefox OS and iOS.