### PR TITLE
Translation bug app name

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -21,6 +21,6 @@ $app->getContainer()->getServer()->getNavigationManager()->add([
         'order' => 10,
         'href' => $serverContainer->getURLGenerator()->linkToRoute('notes.page.index'),
         'icon' => $serverContainer->getURLGenerator()->imagePath('notes', 'notes.svg'),
-        'name' => $serverContainer->getL10N('Notes')->t('Notes'),
+        'name' => $serverContainer->getL10N('notes')->t('Notes'),
     ]
 );


### PR DESCRIPTION
The getL10N won't work for the app name, if your reference is incorrect. 

Line 16 reads: 
$app = new App('notes')

so your reference should be with lower N:
'name' => $serverContainer->getL10N('notes')->t('Notes'),
instead of
'name' => $serverContainer->getL10N('Notes')->t('Notes'),

Checked, works now.