### PR TITLE
Markdown style improvements

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -151,7 +151,6 @@
 
 .markdown h1, h2, h3 {
     font-weight: bold;
-    text-decoration: underline;
     margin-top: 10px;
 }
 

--- a/css/notes.css
+++ b/css/notes.css
@@ -138,12 +138,19 @@
 }
 
 #app-content .utils {
-    padding: 0 20px 0 20px;
-    line-height: 30px;
     position: fixed;
-    top: 45px;
-    right: 20px;
+    top: 58px;
+    right: 10px;
+    opacity: .5;
 }
+
+    #app-content .utils label {
+        padding: 13px;
+    }
+
+    #app-content .utils input[type='checkbox'] {
+        vertical-align: middle;
+    }
 
     #app-content .utils > * {
 

--- a/css/notes.css
+++ b/css/notes.css
@@ -262,5 +262,5 @@
 }
 
     .markdown a:hover {
-        text-decoration: underline;
+        border-bottom: 1px dotted;
     }


### PR DESCRIPTION
* remove ugly underline from Markdown headings
* improve look of Markdown link underline, don’t cut through text
* improve look and clickability of Markdown checkbox

Please review @Raydiation @LukasReschke :)