### PR TITLE
Fix directory name in ApiControllerTest

### DIFF
--- a/tests/integration/controller/NotesApiControllerTest.php
+++ b/tests/integration/controller/NotesApiControllerTest.php
@@ -23,7 +23,7 @@ class NotesApiControllerTest extends TestCase {
     private $controller;
     private $mapper;
     private $userId = 'test';
-    private $notesFolder = '/test/notes';
+    private $notesFolder = '/test/files/Notes';
     private $fs;
 
     public function setUp() {


### PR DESCRIPTION
fixes #121 

 @Raydiation I don't understand why the directory name has to be this way. Maybe you can explain it to me...