### PR TITLE
Increase scrutinizer timeout

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,4 +13,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 300
+        timeout: 600


### PR DESCRIPTION
Increase timeout of scrutinizer code coverage from 5 minutes to 10 minutes.