### PR TITLE
Revert background rule combination in 3e474e4

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -21,7 +21,10 @@
 
 #app-navigation .utils button {
     margin: 0;
-    background: transparent no-repeat center;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: transparent;
+
     border: 0;
     box-shadow: none;
     display: none;


### PR DESCRIPTION
Because some background rules where combined in 3e474e4, the delete icon is hidden.
This is reverted in this PR.