### PR TITLE
override snap.js animation causing loading icon to fly into app-content

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -24,12 +24,17 @@
     background-position: center;
     background-repeat: no-repeat;
     background-color: transparent;
-
     border: 0;
     box-shadow: none;
     display: none;
     height: 32px;
     width: 32px;
+}
+
+/* override snap.js animation causing loading icon to fly into app-content */
+#app-content.loading {
+    transition: none !important;
+    -webkit-transition: none !important;
 }
 
 /* only display the delete button when the feed is active */


### PR DESCRIPTION
We need that after all to prevent the flying in. This only happens in the Notes app, so only fixing here. @Henni @BernhardPosselt @LukasReschke @matthias-g please review.