### PR TITLE
Increase scrutinizer timeout of external code coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,4 +13,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 600
+        timeout: 1800


### PR DESCRIPTION
sets timeout to 30 minutes.