### PR TITLE
Allow file extensions other than txt

### DIFF
--- a/db/note.php
+++ b/db/note.php
@@ -20,8 +20,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setId(integer $value)
  * @method integer getModified()
  * @method void setModified(integer $value)
- * @method integer getContent()
- * @method void setContent(integer $value)
+ * @method string getTitle()
+ * @method void setTitle(string $value)
+ * @method string getContent()
+ * @method void setContent(string $value)
  * @package OCA\Notes\Db
  */
 class Note extends Entity {
@@ -43,7 +45,7 @@ class Note extends Entity {
         $note->setId($file->getId());
         $note->setContent($file->getContent());
         $note->setModified($file->getMTime());
-        $note->setTitle(substr($file->getName(), 0, -4)); // remove trailing .txt
+        $note->setTitle(pathinfo($file->getName(),PATHINFO_FILENAME)); // remove extension
         $note->resetUpdatedFields();
         return $note;
     }

--- a/tests/unit/service/NotesServiceTest.php
+++ b/tests/unit/service/NotesServiceTest.php
@@ -84,7 +84,7 @@ class NotesServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetAll(){
         $nodes = [];
         $nodes[] = $this->createNode('file1.txt', 'file', 'text/plain');
-        $nodes[] = $this->createNode('file2.txt', 'file', 'text/xml');
+        $nodes[] = $this->createNode('file1.jpg', 'file', 'image/jpeg');
         $nodes[] = $this->createNode('file3.txt', 'folder', 'text/plain');
 
         $this->expectUserFolder();
@@ -133,9 +133,9 @@ class NotesServiceTest extends PHPUnit_Framework_TestCase {
     /**
      * @expectedException OCA\Notes\Service\NoteDoesNotExistException
      */
-    public function testGetDoesNotExistWrongMime(){
+    public function testGetDoesNotExistWrongExtension(){
             $nodes = [];
-        $nodes[] = $this->createNode('file1.txt', 'file', 'text/xml');
+        $nodes[] = $this->createNode('file1.jpg', 'file', 'image/jpeg');
 
         $this->expectUserFolder();
         $this->userFolder->expects($this->once())
@@ -183,9 +183,9 @@ class NotesServiceTest extends PHPUnit_Framework_TestCase {
     /**
      * @expectedException OCA\Notes\Service\NoteDoesNotExistException
      */
-    public function testDeleteDoesNotExistWrongMime(){
+    public function testDeleteDoesNotExistWrongExtension(){
         $nodes = [];
-        $nodes[] = $this->createNode('file1.txt', 'file', 'text/xml');
+        $nodes[] = $this->createNode('file1.jpg', 'file', 'image/jpeg');
 
         $this->expectUserFolder();
         $this->userFolder->expects($this->once())


### PR DESCRIPTION
This PR adds the file extensions:
* .md
* .markdown
* .org
* .note

Files with these extensions are detected by the app, and keep their extension.
All new notes have the extension `.txt`.

fixes #111 

Please review @gerroon @tapir @grefel @pierrejochem 