### PR TITLE
Update owncloud version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
     <bugs>https://github.com/owncloud/notes/issues</bugs>
     <repository type="git">https://github.com/owncloud/notes.git</repository>
     <dependencies>
-        <owncloud min-version="10.0" max-version="10.1" />
+        <owncloud min-version="10" max-version="10" />
     </dependencies>
     <screenshot>https://cloud.githubusercontent.com/assets/4741199/17731273/e557b5fe-646c-11e6-9975-d6b242454482.png</screenshot>
     <navigation role="admin">


### PR DESCRIPTION
> App developers should re-release their apps after setting the “max-version” field to “10” instead of “10.0” in “appinfo/info.xml”, and increase the app’s version as well
to make sure ownCloud picks up the change. This is required because else ownCloud 10.1 will think that the apps are not compatible any more and will refuse to update or enable them.

https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054