### PR TITLE
Bump karma 0.13.3 to 6.3.4

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -24,7 +24,7 @@
     "gulp-wrap": "^0.15.0",
     "jasmine-core": "^3.1.0",
     "jshint-stylish": "^2.0.1",
-    "karma": "^0.13.3",
+    "karma": "^6.3.4",
     "karma-jasmine": "^4.0.1",
     "karma-phantomjs-launcher": "*",
     "phantomjs-prebuilt": "*"


### PR DESCRIPTION
Like PR #391 - drone CI is not starting there.

We need to update as much JS dependencies as possible to get CI working with nodejs:14 PR #397 