### PR TITLE
[tests-only] Update drone starlark and drop PHP 7.2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -591,7 +591,7 @@ def javascript(ctx, withCoverage):
                  [
                      {
                          "name": "js-tests",
-                         "image": "owncloudci/nodejs:%s" % getNodeJsVersion(),
+                         "image": "owncloudci/php:8.0",
                          "pull": "always",
                          "environment": params["extraEnvironment"],
                          "commands": params["extraCommandsBeforeTestRun"] + [

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@
 #    },
 
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
 
 app_name=$(notdir $(CURDIR))
 build_tools_directory=$(CURDIR)/build/tools

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "owncloud/notes",
     "config" : {
         "platform": {
-            "php": "7.1"
+            "php": "7.3"
         }
     },
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.3"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4342d6ca0e5c3955e284495c6070fbfb",
+    "content-hash": "9a6bbd4ddb9d7132a602b6cf28194d1e",
     "packages": [],
     "packages-dev": [
         {
@@ -64,11 +64,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1"
+        "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,5 +29,5 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,results/clover-phpunit-php7.2-mysql8.0.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-oracle.xml,results/clover-phpunit-php7.2-sqlite.xml,results/clover-phpintegration-php7.2-mariadb10.2.xml,results/clover-phpintegration-php7.2-mysql8.0.xml,results/clover-phpintegration-php7.2-postgres9.4.xml,results/clover-phpintegration-php7.2-oracle.xml,results/clover-phpintegration-php7.2-sqlite.xml
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.3-mariadb10.2.xml,results/clover-phpunit-php7.3-mysql8.0.xml,results/clover-phpunit-php7.3-postgres9.4.xml,results/clover-phpunit-php7.3-oracle.xml,results/clover-phpunit-php7.3-sqlite.xml,results/clover-phpintegration-php7.3-mariadb10.2.xml,results/clover-phpintegration-php7.3-mysql8.0.xml,results/clover-phpintegration-php7.3-postgres9.4.xml,results/clover-phpintegration-php7.3-oracle.xml,results/clover-phpintegration-php7.3-sqlite.xml
 sonar.javascript.lcov.reportPaths=results/lcov.info


### PR DESCRIPTION
Part of issue https://github.com/owncloud/QA/issues/687

In the 2nd commit, I have reverted the changes to `owncloudci/nodejs:14` for running the JS tests. For some reason, the JS tests in the notes app do not pass with the new nodejs 14 docker image. I raised issue #405 to look into that.

For now, we can get all the other "drop PHP 7.2" etc changes merged.