### PR TITLE
[tests-only] [full-ci] Enable phpstan

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -54,6 +54,7 @@ config = {
             ],
         },
     },
+    "phpstan": True,
     "javascript": True,
     "phpunit": True,
     "phpintegration": True,

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ PHPUNIT=php -d zend.enable_gc=0  "$(PWD)/../../lib/composer/bin/phpunit"
 PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
 PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
+PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 
 all: build
 
@@ -208,6 +209,11 @@ test-php-phan: ## Run phan
 test-php-phan: vendor-bin/phan/vendor
 	$(PHAN) --config-file .phan/config.php --require-config-exists
 
+.PHONY: test-php-phpstan
+test-php-phpstan: ## Run phpstan
+test-php-phpstan: vendor-bin/phpstan/vendor
+	$(PHPSTAN) analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo controller db service
+
 .PHONY: test-js
 test-js: ## Test js files
 test-js: npm
@@ -237,3 +243,9 @@ vendor-bin/phan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phan/compo
 
 vendor-bin/phan/composer.lock: vendor-bin/phan/composer.json
 	@echo phan composer.lock is not up to date.
+
+vendor-bin/phpstan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phpstan/composer.lock
+	composer bin phpstan install --no-progress
+
+vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
+	@echo phpstan composer.lock is not up to date.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,17 @@
+parameters:
+  inferPrivatePropertyTypeFromConstructor: true
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
+  ignoreErrors:
+    -
+      message: '#Unsafe usage of new static\(\).#'
+      path: db/note.php
+    -
+      message: '#Strict comparison using === between string and null will always evaluate to false.#'
+      path: service/notesservice.php
+    -
+      message: '#Method OCA\\Notes\\Service\\NotesService::getFileById\(\) should return OCP\\Files\\File but returns OCP\\Files\\Node.#'
+      path: service/notesservice.php
+    -
+      message: '#Method OCA\\Notes\\Service\\NotesService::getFolderForUser\(\) should return OCP\\Files\\Folder but returns OCP\\Files\\Node.#'
+      path: service/notesservice.php

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -56,7 +56,10 @@ class NotesService {
 		}
 
 		$notes = [];
-		foreach ($filesById as $id=>$file) {
+		foreach ($filesById as $id => $file) {
+			/**
+			 * @var \OCP\Files\File $file
+			 */
 			$notes[] = Note::fromFile($file, \array_key_exists($id, $tags) ? $tags[$id] : []);
 		}
 
@@ -255,7 +258,7 @@ class NotesService {
 	/**
 	 * test if file is a note
 	 *
-	 * @param \OCP\Files\File $file
+	 * @param \OCP\Files\File|\OCP\Files\Node $file
 	 * @return bool
 	 */
 	private function isNote($file) {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1.2"
+    }
+}


### PR DESCRIPTION
when checking if ny changes are needed for Symfony5, I noticed that `phpstan` is not being run.
`phpstan` is good at finding method calls, parameter types, etc. that are not correct.
So I have got it running, made minimal changes to code annotations, and put the remaining things into `ignoreErrors` - there is nothing really important found.