### PR TITLE
test: adjust PHPstan ignoreErrors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,10 +4,6 @@ parameters:
     - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
     -
-      message: '#Unsafe usage of new static\(\).#'
-      path: db/note.php
-      count: 1
-    -
       message: '#Strict comparison using === between string and null will always evaluate to false.#'
       path: service/notesservice.php
       count: 1


### PR DESCRIPTION
The new release of phpstan no longer complains about unsafe usage of "new static". So this no longer needs to be ignored.

Fixes #471 