### PR TITLE
chore: prepare 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 
 
+## [2.1.0] - 2026-07-06
+
+### Changed
+ * [#526](https://github.com/owncloud/notes/pull/526) - Compatible with ownCloud 11
+ * [#528](https://github.com/owncloud/notes/pull/528) - Require PHP 8.3
+ * Development dependencies updated
+
 ## [2.0.7] - 2024-09-23
 
 ### Fixed


### PR DESCRIPTION
## Summary

Prepare the **2.1.0** release of the Notes app.

`appinfo/info.xml` is already at `version 2.1.0` with oc11 / PHP 8.3 dependencies; this PR just materialises the `## [Unreleased]` changelog section into a dated `## [2.1.0]` entry so the release can be tagged.

### Notable changes since 2.0.7
- [#526](https://github.com/owncloud/notes/pull/526) — Compatible with ownCloud 11
- [#528](https://github.com/owncloud/notes/pull/528) — Require PHP 8.3

## Context

2.1.0 is the first Notes release marked oc11-compatible; it is being cut so it can be bundled into the ownCloud 11 complete release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)