### PR TITLE
fix(ci): increase karma capture timeout to avoid flaky Chrome launches

### DIFF
--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -85,8 +85,14 @@ module.exports = function(config) {
             }
         },
 
-        // If browser does not capture in given timeout [ms], kill it
-        captureTimeout: 5000,
+        // If browser does not capture in given timeout [ms], kill it.
+        // Cold CI runners need ample time to download/spawn headless Chrome;
+        // the previous 5s value caused frequent flaky launch timeouts.
+        captureTimeout: 60000,
+
+        // Retry capturing the browser a few times before giving up, to ride
+        // out transient launch hiccups on CI.
+        browserDisconnectTolerance: 2,
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
## Problem

The **JS Unit** CI job failed on master ([run 29004103213](https://github.com/owncloud/notes/actions/runs/29004103213)) for a translation-only commit (#534) that touches no JavaScript.

The logs show the tests never ran — ChromeHeadless failed to *launch* within the configured timeout:

```
ChromeHeadless has not captured in 5000 ms, killing.
ChromeHeadless failed 2 times (timeout). Giving up.
```

Re-running the identical job with no code changes passed, confirming a flaky, environmental launch timeout rather than a code regression.

## Root cause

`js/karma.conf.js` set `captureTimeout: 5000` (unchanged since 2014). 5 seconds is too tight for a cold GitHub Actions runner to download and spawn headless Chrome — Karma's default is 60000ms.

## Fix

- Raise `captureTimeout` from `5000` → `60000` (Karma default).
- Add `browserDisconnectTolerance: 2` to ride out transient launch hiccups.

No test logic is changed. This only affects how long CI waits for the browser to come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)