### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased] 
 
 
+## [2.1.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
 
 ## [2.1.0] - 2026-07-06
 
@@ -80,7 +84,9 @@ owncloud-notes (0.2)
 * Remember last note
 * Fixed various bugs
 
-[Unreleased]: https://github.com/owncloud/notes/compare/v2.0.7...master
+[Unreleased]: https://github.com/owncloud/notes/compare/v2.1.1..master
+[2.1.1]: https://github.com/owncloud/notes/compare/v2.1.0..v2.1.1
+[2.1.0]: https://github.com/owncloud/notes/compare/v2.0.7..v2.1.0
 [2.0.7]: https://github.com/owncloud/notes/compare/v2.0.6...v2.0.7
 [2.0.6]: https://github.com/owncloud/notes/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/owncloud/notes/compare/v2.0.4...v2.0.5

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Notes</name>
     <licence>AGPL</licence>
     <author>Bernhard Posselt, Jan-Christoph Borchardt, Hendrik Leppelsack</author>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <namespace>Notes</namespace>
     <category>tools</category>
     <summary>Distraction-free notes and writing</summary>


### PR DESCRIPTION
Patch-level version bump (2.1.0 -> 2.1.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.