### PR TITLE
fix(favorite): avoid 500 when unfavoriting a note with no tags left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   instead of a blank white area.
 
 ### Fixed
+- Unfavoriting a note no longer returns HTTP 500. When a note had no tags left
+  after removing the favorite, `getTagsForObjects()` returns no entry for the
+  note id, so `in_array()` was called with `null` and threw a `TypeError`. Guard
+  the lookup with `array_key_exists()`, matching the pattern already used
+  elsewhere in `NotesService`.
 - Restore the empty AngularJS hash prefix so clicking a note in the sidebar
   opens it again. The AngularJS 1.8 upgrade changed the default hash prefix to
   `!`, which broke the `#/notes/{id}` sidebar links so only the first note (or

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -181,7 +181,8 @@ class NotesService {
 		}
 
 		$tags = $tagger->getTagsForObjects([$id]);
-		return \in_array(\OC\Tags::TAG_FAVORITE, $tags[$id]);
+		$noteTags = \array_key_exists($id, $tags) ? $tags[$id] : [];
+		return \in_array(\OC\Tags::TAG_FAVORITE, $noteTags);
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Fixes #553.

Unfavoriting a note returns **HTTP 500** even though the favorite state is actually removed and persisted:

```
Undefined array key 2147485371 at .../service/notesservice.php#184
TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given
```

## Root cause

In `NotesService::favorite()`, after `removeFromFavorites($id)` a note may have **no tags left**. In that case `getTagsForObjects([$id])` returns an array **without** the `$id` key. The old code read `$tags[$id]` unconditionally:

```php
$tags = $tagger->getTagsForObjects([$id]);
return \in_array(\OC\Tags::TAG_FAVORITE, $tags[$id]); // $tags[$id] is null -> TypeError
```

`$tags[$id]` evaluates to `null`, and `in_array()` with a `null` haystack throws a `TypeError` → 500. The removal itself already succeeded, which is why the Files app shows the note correctly un-favorited.

## Fix

Guard the lookup with `array_key_exists()`, exactly matching the defensive pattern already used in `getAll()` and `getTags()` in the same file:

```php
$tags = $tagger->getTagsForObjects([$id]);
$noteTags = \array_key_exists($id, $tags) ? $tags[$id] : [];
return \in_array(\OC\Tags::TAG_FAVORITE, $noteTags);
```

## Verification

The static `\OC::$server->getTagManager()` call in `favorite()` cannot be mocked in the existing unit harness (which is why there are no favorite unit tests). I reproduced the exact failure and confirmed the fix in an isolated script: the buggy expression raises the same `Undefined array key` warning + `in_array(): ... null given` TypeError from the issue, and the fixed expression returns `false` (the correct new favorite state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)