### PR TITLE
docs(agents): require translations when source strings change

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -51,6 +51,11 @@ make dist                     # Create distribution package
 - Review and merge Dependabot PRs as part of regular maintenance.
 - Do not introduce new dependencies without discussion in an issue first.
 
+### Translations
+- When you add or change a translatable source string (`$l->t()` / `p($l->t())` in `templates/`, or `t()` / `n()` in `js/`), you **must** add the matching entries to every `l10n/<lang>.js` and `l10n/<lang>.json` file.
+- Keep each language's `.js` and `.json` pair in sync, and preserve each file's existing `pluralForm`; plural strings need one array element per `nplurals`.
+- Translations are maintained in-repo (no Transifex); include them in the same PR as the source-string change.
+
 ### Git Workflow
 - **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
 - **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).


### PR DESCRIPTION
Adds a **Translations** rule to `agents.md` so AI agents and contributors keep the `l10n/` catalogs in sync whenever translatable source strings change.

## Why
Translations are moving from Transifex to in-repo maintenance (see companion PR retiring the Transifex sync). This codifies the new expectation: a source-string change must carry its translation updates in the same PR.

## Change
New `### Translations` subsection under `## OSPO Policy Constraints`:
- Source-string changes (`$l->t()`/`p()` in `templates/`, `t()`/`n()` in `js/`) must update every `l10n/<lang>.js` + `.json`.
- Keep `.js`/`.json` pairs in sync; preserve each file's `pluralForm`; plural arrays need one element per `nplurals`.
- Translations are maintained in-repo (no Transifex); include them in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)