### PR TITLE
fix(css): add background box for fenced code blocks (#439)

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -143,6 +143,15 @@
 }
 
 
+/* fenced code blocks (``` ... ```) */
+.mdedit .code-block {
+    background: rgba(120, 120, 120, 0.1);
+    padding: 0 0.5em;
+    margin: 0.5em 0;
+    display: block;
+}
+
+
 /* hanging punctuation */
 #app-content .mdedit {
     padding-left: 45px;


### PR DESCRIPTION
## What

Adds a `.mdedit .code-block` rule so fenced code blocks (```` ``` ... ``` ````) render as a distinct box with a subtle background, padding and block display.

## Why

Fenced code blocks were already tokenized by the vendored mdEdit/Prism renderer (`js/vendor/mdEdit/src/md.js`), but the stylesheet only gave them a text color — no background — so they were visually indistinguishable from surrounding text. This matches the reused-looking treatment inline `.code` already gets in `mdedit.css`.

Reported in #439.

## Scope

This is the minimal, focused version of the CSS change originally proposed in #440. That PR bundled several unrelated changes (a search feature, a PWA manifest, `.gitignore` build-artifact entries, and a `templates/note.php` DOM change) and had gone stale with merge conflicts, so #440 is being closed in favor of this single-purpose PR.

## Testing

Manual: a fenced ```` ``` ```` block in a note now renders with a shaded background box; inline and non-code text are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)