### PR TITLE
fix(l10n): remove duplicate de/de_DE empty-state keys

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -5,11 +5,9 @@ OC.L10N.register(
     "Note is currently saving. Leaving the page will delete all changes!" : "Notizen werden gerade gespeichert. Das Verlassen der Seite löscht alle Änderungen!",
     "_%n word_::_%n words_" : ["%n Wort","%n Wörter"],
     "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über den +-Button in der Seitenleiste.",
+    "Create a note using the + button in the sidebar." : "Erstelle eine Notiz über die +-Schaltfläche in der Seitenleiste.",
     "Delete note" : "Notiz löschen",
     "Favorite" : "Favorisieren",
-    "Notes" : "Notizen",
-    "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstelle eine Notiz über die +-Schaltfläche in der Seitenleiste."
+    "Notes" : "Notizen"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -3,11 +3,9 @@
     "Note is currently saving. Leaving the page will delete all changes!" : "Notizen werden gerade gespeichert. Das Verlassen der Seite löscht alle Änderungen!",
     "_%n word_::_%n words_" : ["%n Wort","%n Wörter"],
     "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über den +-Button in der Seitenleiste.",
+    "Create a note using the + button in the sidebar." : "Erstelle eine Notiz über die +-Schaltfläche in der Seitenleiste.",
     "Delete note" : "Notiz löschen",
     "Favorite" : "Favorisieren",
-    "Notes" : "Notizen",
-    "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstelle eine Notiz über die +-Schaltfläche in der Seitenleiste."
+    "Notes" : "Notizen"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -8,8 +8,6 @@ OC.L10N.register(
     "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über die +-Schaltfläche in der Seitenleiste.",
     "Delete note" : "Notiz löschen",
     "Favorite" : "Favorit",
-    "Notes" : "Notizen",
-    "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über die Schaltfläche + in der Seitenleiste."
+    "Notes" : "Notizen"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -6,8 +6,6 @@
     "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über die +-Schaltfläche in der Seitenleiste.",
     "Delete note" : "Notiz löschen",
     "Favorite" : "Favorit",
-    "Notes" : "Notizen",
-    "No note selected" : "Keine Notiz ausgewählt",
-    "Create a note using the + button in the sidebar." : "Erstellen Sie eine Notiz über die Schaltfläche + in der Seitenleiste."
+    "Notes" : "Notizen"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }


### PR DESCRIPTION
Fixes duplicate translation keys introduced by the all-languages backfill (#561, now merged to `master`).

## Problem
`de` and `de_DE` already carried `No note selected` and `Create a note using the + button in the sidebar.` from #552. The backfill appended both keys again with different wording, producing the **same key twice in a single catalog object** — a malformed JS object literal / JSON object resolved only by implicit last-wins. JSON parsers accept it, which is why validation didn't catch it.

## Fix
Collapse each affected catalog to a single, register-correct entry (`de` = informal *du*, `de_DE` = formal *Sie* — intentionally distinct catalogs):

- **`de`** — keeps the informal `Erstelle eine Notiz über die +-Schaltfläche …` (register-correct for the informal catalog; the duplicated #552 line was a formal *Erstellen Sie* string).
- **`de_DE`** — keeps the formal `Erstellen Sie eine Notiz über die +-Schaltfläche …`.
- The genuinely new `Notes` key added by the backfill is retained in both.

Only these 4 files change (`de.{js,json}`, `de_DE.{js,json}`); no other locale had a pre-existing `No note selected`/`Create a note` key, so none is affected.

## Verification
- No duplicate keys remain in any of the 4 files.
- JSON re-validated for `de.json` / `de_DE.json`.
- `.js`/`.json` message keys in sync per catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
