### PR TITLE
ci: gate against duplicate keys in l10n catalogs

### DIFF
--- a/.github/workflows/l10n-lint.yml
+++ b/.github/workflows/l10n-lint.yml
@@ -1,0 +1,28 @@
+name: l10n lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: l10n-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  duplicate-keys:
+    name: Duplicate translation keys
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check l10n catalogs for duplicate keys
+        run: make test-l10n

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,11 @@ test-js: ## Test js files
 test-js: npm
 	cd js && npm run test
 
+.PHONY: test-l10n
+test-l10n: ## Check l10n catalogs for duplicate translation keys
+test-l10n:
+	python3 tests/l10n/check-duplicate-keys.py
+
 .PHONY: test-acceptance-webui
 test-acceptance-webui: ## Run webUI acceptance tests
 test-acceptance-webui: $(acceptance_test_deps)

--- a/tests/l10n/check-duplicate-keys.py
+++ b/tests/l10n/check-duplicate-keys.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fail if any l10n catalog contains a duplicate translation key.
+
+Both ``JSON.parse`` (JS) and PHP ``json_decode`` silently collapse duplicate
+object keys (last value wins), so a catalog can carry the same key twice and
+still "validate" while being malformed. That is exactly how the duplicate
+``de``/``de_DE`` empty-state keys reached master (see PR #562). This checker
+inspects *all* key/value pairs before deduplication via ``object_pairs_hook``
+and reports any key that appears more than once.
+
+Covers both catalog formats:
+  * ``l10n/<lang>.json`` -- a plain JSON object.
+  * ``l10n/<lang>.js``   -- ``OC.L10N.register("notes", { ... }, "plural...");``
+                            where the ``{ ... }`` object literal is JSON.
+
+Exit code 0 when every catalog is clean, 1 when duplicates are found (or a
+catalog cannot be parsed).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Repo root is two levels up from tests/l10n/.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+L10N_DIR = REPO_ROOT / "l10n"
+
+
+def make_pairs_hook(collector):
+    """Build an object_pairs_hook that appends duplicate keys to ``collector``.
+
+    The hook runs for *every* object in the document (including nested ones such
+    as the ``translations`` wrapper in the .json catalogs) and fires before
+    Python collapses duplicate keys, so it sees all of them.
+    """
+    def hook(pairs):
+        seen = set()
+        for key, _value in pairs:
+            if key in seen:
+                collector.append(key)
+            else:
+                seen.add(key)
+        return dict(pairs)
+    return hook
+
+
+def extract_js_object(text):
+    """Return the JSON object literal embedded in an OC.L10N.register call.
+
+    The catalog is ``OC.L10N.register("notes", { ... }, "plural...");``. We take
+    the first ``{`` and its matching ``}`` (tracking string literals so braces
+    inside translations are ignored) and return that substring.
+    """
+    start = text.find("{")
+    if start == -1:
+        raise ValueError("no '{' found in .js catalog")
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    raise ValueError("unbalanced braces in .js catalog")
+
+
+def duplicates_in_file(path):
+    """Return the list of duplicate keys in one catalog file.
+
+    Collects duplicates from every object in the document, so a duplicate inside
+    the nested ``translations`` object of a .json catalog is caught too.
+    """
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".js":
+        text = extract_js_object(text)
+    dups = []
+    json.loads(text, object_pairs_hook=make_pairs_hook(dups))
+    return dups
+
+
+def main():
+    catalogs = sorted(
+        p for p in L10N_DIR.iterdir()
+        if p.suffix in (".js", ".json")
+    )
+    if not catalogs:
+        print(f"error: no catalogs found in {L10N_DIR}", file=sys.stderr)
+        return 1
+
+    failures = []
+    for path in catalogs:
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            dups = duplicates_in_file(path)
+        except (ValueError, json.JSONDecodeError) as exc:
+            failures.append(f"{rel}: could not parse ({exc})")
+            continue
+        if dups:
+            for key in dups:
+                failures.append(f"{rel}: duplicate key {json.dumps(key, ensure_ascii=False)}")
+
+    if failures:
+        print("Duplicate translation keys detected:", file=sys.stderr)
+        for line in failures:
+            print(f"  {line}", file=sys.stderr)
+        print(
+            f"\n{len(failures)} problem(s) across {len(catalogs)} catalog files.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: no duplicate keys in {len(catalogs)} l10n catalog files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a CI gate that fails when any `l10n/*.{js,json}` catalog contains a duplicate translation key — the class of defect that slipped through in #561 and needed the follow-up fix in #562.

## Why a dedicated checker
Both `JSON.parse` (JS) and PHP `json_decode` **silently collapse duplicate object keys** (last value wins). So a catalog can carry the same key twice, still parse as "valid JSON", and quietly ship a last-wins translation. Plain JSON validation cannot catch this — the checker inspects **all** key/value pairs *before* deduplication via `json`'s `object_pairs_hook`.

## Changes
- **`tests/l10n/check-duplicate-keys.py`** — scans every catalog and reports each duplicated key.
  - `.json`: parsed directly; the hook runs on the nested `translations` object too.
  - `.js`: the `OC.L10N.register("notes", { … }, "plural…")` wrapper is stripped (brace-matching that respects string literals) and the inner object is parsed with the same hook.
  - Exits non-zero listing every offending `file: key`; placed under `tests/l10n/` (not `l10n/`, which the `appstore` build copies wholesale into the package).
- **`Makefile`** — `make test-l10n` target, mirroring the existing `test-*` targets, as the shared entrypoint for CI and local runs.
- **`.github/workflows/l10n-lint.yml`** — dedicated workflow (push to master + PRs) running `make test-l10n`. `actions/checkout` is SHA-pinned to v7.0.1; Python 3 comes preinstalled on `ubuntu-latest`, so no extra action is needed. `github-actions` Dependabot coverage already exists to keep the pin current.

## Verification
- `make test-l10n` passes on current `master` (138 catalogs, clean post-#562).
- Injecting a duplicate into a `.js` and into the nested object of a `.json` each fail with the right file + key.
- Run against the pre-#562 tree (`bf8b73f8`), the checker flags the exact `de`/`de_DE` `No note selected` / `Create a note…` duplicates — i.e. it would have blocked #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
