### PR TITLE
feat: publish a signed release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: notes
+      # notes emits two tarballs both named notes.tar.gz (source and appstore);
+      # publish only the appstore one, otherwise the release assets collide.
+      artifact-glob: build/artifacts/appstore/*.tar.gz
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ endif
 # * the certificate is located in ~/.owncloud/notes.crt
 occ=$(CURDIR)/../../occ
 phpunit_oc10=$(CURDIR)/../../lib/composer/bin/phpunit
-configdir=$(CURDIR)/../../config
 private_key=$(HOME)/.owncloud/certificates/$(app_name).key
 certificate=$(HOME)/.owncloud/certificates/$(app_name).crt
 sign=php -f $(occ) integrity:sign-app --privateKey="$(private_key)" --certificate="$(certificate)"
@@ -168,9 +167,7 @@ appstore: build
 	"CHANGELOG.md" \
 	$(appstore_build_directory)
 ifdef CAN_SIGN
-	mv $(configdir)/config.php $(configdir)/config-2.php
 	$(sign) --path="$(appstore_build_directory)"
-	mv $(configdir)/config-2.php $(configdir)/config.php
 else
 	@echo $(sign_skip_msg)
 endif


### PR DESCRIPTION
## What

Adds a `Release` workflow: on a `v*` tag push, `make dist` runs, the bundle is
signed, and the tarball is attached to a GitHub Release. Delegates to
[`owncloud/reusable-workflows`](https://github.com/owncloud/reusable-workflows/pull/87).

## Why

`make dist` in CI has been silently producing **unsigned** tarballs. `CAN_SIGN`
is only set when key, cert *and* `occ` all exist locally, so the `else` branch
just echoes a message and the build still exits 0:

```
$ make dist
Skipping signing, either no key and certificate found in ... or occ can not be found
$ tar tzf build/<app>.tar.gz | grep -c signature.json
0
$ echo $?
0
```

Signing is **mandatory on ownCloud 11+** — an unsigned app is blocked, not
warned. Signing now uses [`ocsign`](https://github.com/owncloud/ocsign), which
needs no ownCloud server, and the reusable workflow **asserts** the tarball
carries a valid `appinfo/signature.json` whose leaf `CN` matches the app id.

## Two Makefile changes this app needs

**The `configdir` workaround is removed.** `appstore:` moved
`../../config/config.php` aside around the sign call, so `occ` would not read
the app's own config. ocsign reads no config, and without a core checkout that
path does not exist, so the `mv` failed outright:

```
mv: cannot stat '.../notes/../../config/config.php': No such file or directory
make[1]: *** [Makefile:157: appstore] Error 1
```

Both lines are gone, which leaves `configdir` unreferenced, so its definition
goes too. Verified: with the patch, `make dist` signs and tars cleanly.

**`artifact-glob` is narrowed.** `make dist` emits two tarballs, both named
`notes.tar.gz` — `build/artifacts/source/` and `build/artifacts/appstore/`. As
release assets they would collide, so only the appstore bundle is published.

## Before this can publish

The `SIGNING_KEY`, `SIGNING_CERT` and `SIGNING_CHAIN` secrets must be set on
this repository. Without them the release job fails fast with a clear message
rather than shipping something unsigned.

The workflow also requires the pushed tag (minus the leading `v`) to equal
`<version>` in `appinfo/info.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
