### PR TITLE
chore: temporary probe to verify the license/cla status posts

### DIFF
--- a/.cla-verify-probe
+++ b/.cla-verify-probe
@@ -1,0 +1,2 @@
+Temporary probe to confirm the cla-assistant webhook posts license/cla.
+This branch and PR are deleted immediately after verification.


### PR DESCRIPTION
Throwaway verification PR — **do not review, do not merge.**

owncloud/notes was just linked at cla-assistant.io as part of owncloud/admin#264.
Before requiring `license/cla` as a status check in safe-settings, I need to
confirm the webhook actually posts the status (a required context that never
reports blocks every merge on the branch).

This PR exists only to fire one `pull_request` event. It will be closed and the
branch deleted as soon as the status is observed.