### PR TITLE
chore: temporary probe to verify the license/cla status posts

### DIFF
--- a/.cla-verify-probe
+++ b/.cla-verify-probe
@@ -1,0 +1,2 @@
+Temporary probe confirming the cla-assistant webhook posts license/cla.
+Deleted immediately after verification.


### PR DESCRIPTION
Throwaway verification PR — **do not review, do not merge.**

This repo was just linked at cla-assistant.io as part of owncloud/admin#264. Before requiring `license/cla` in safe-settings I must confirm the webhook actually posts the status — a required context that never reports blocks every merge.

Closed and branch deleted as soon as the status is observed.